### PR TITLE
Use correct comment prefix in .env code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ main()
 
 ```
 
-// Go to https://www.alchemyapi.io, sign up, create
-// a new App in its dashboard and select the network as Rinkeby, and replace "add-the-alchemy-key-url-here" with its key url
+# Go to https://www.alchemyapi.io, sign up, create
+# a new App in its dashboard and select the network as Rinkeby, and replace "add-the-alchemy-key-url-here" with its key url
 ALCHEMY_API_KEY_URL="add-the-alchemy-key-url-here"
 
-// Replace this private key with your RINKEBY account private key
-// To export your private key from Metamask, open Metamask and
-// go to Account Details > Export Private Key
-// Be aware of NEVER putting real Ether into testing accounts
+# Replace this private key with your RINKEBY account private key
+# To export your private key from Metamask, open Metamask and
+# go to Account Details > Export Private Key
+# Be aware of NEVER putting real Ether into testing accounts
 RINKEBY_PRIVATE_KEY="add-the-rinkeby-private-key-here"
 
 ```


### PR DESCRIPTION
Comments in .env are done with a #, not //
The comments are nice to keep, so it would be useful to be able to copy this without this tripping anyone up!